### PR TITLE
Show type and colour definition in addition to the rendered colour.

### DIFF
--- a/scripts/colours.sh
+++ b/scripts/colours.sh
@@ -35,5 +35,5 @@ do
         *) TEXT="${TYPE} (TODO: get description)";;
     esac
 
-    echo -e "\e[${COLOUR}m${TEXT}\e[0m"
+    echo -e "Type: ${TYPE}\tColour {$COLOUR}\t\e[${COLOUR}m${TEXT}\e[0m"
 done

--- a/scripts/colours.sh
+++ b/scripts/colours.sh
@@ -35,5 +35,5 @@ do
         *) TEXT="${TYPE} (TODO: get description)";;
     esac
 
-    echo -e "Type: ${TYPE}\tColour {$COLOUR}\t\e[${COLOUR}m${TEXT}\e[0m"
+    printf "Type: %-10s Colour: %-10s \e[${COLOUR}m${TEXT}\e[0m\n" ${TYPE} ${COLOUR}
 done


### PR DESCRIPTION
I was investigating how the colour definitions on my OpenSuSE system actually work internally so I added some extra output: `${TYPE}` and `${COLOUR}`.