### PR TITLE
Quote the variables used to prevent a certain bug

### DIFF
--- a/scripts/colours.sh
+++ b/scripts/colours.sh
@@ -38,5 +38,5 @@ do
         *) TEXT="${TYPE} (TODO: get description)";;
     esac
 
-    printf "Type: %-10s Colour: %-10s \e[${COLOUR}m${TEXT}\e[0m\n" ${TYPE} ${COLOUR}
+    printf "Type: %-10s Colour: %-10s \e[${COLOUR}m${TEXT}\e[0m\n" "${TYPE}" "${COLOUR}"
 done


### PR DESCRIPTION
This fix prevents types which are a glob pattern from getting replaced with the name of an actual file.

For example:
`*.gz` is an archive format, so it should get printed as being a type.
Bash sees it as a glob so it replaces it with `some-archive.gz` and the resulting output ends up containing:
`Type: some-archive.gz Colour: 01;31 some-archive.gz (TODO: get description)`