### PR TITLE
Always add email and signingkey separately

### DIFF
--- a/git/gitconfig_global
+++ b/git/gitconfig_global
@@ -1,6 +1,7 @@
 [user]
     name  = Gautam Kotian
-    email = gautam.kotian@gmail.com
+    ; email = <always added locally in each repo>
+    ; signingkey = <always added locally in each repo>
 
 [giggle]
     main-window-maximized       = true


### PR DESCRIPTION
This helps to ensure that the correct email and signingkey are set for
each repo. This is helpful to avoid associating an incorrect account
with a repo when multiple accounts are used on the same computer.